### PR TITLE
PostItem sorting and pagination

### DIFF
--- a/api/src/main/kotlin/com/gmtkgamejam/plugins/PostRoutes.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/plugins/PostRoutes.kt
@@ -7,10 +7,8 @@ import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
-import org.litote.kmongo.and
-import org.litote.kmongo.contains
-import org.litote.kmongo.eq
-import org.litote.kmongo.regex
+import org.litote.kmongo.*
+import kotlin.reflect.full.memberProperties
 
 fun Application.configurePostRouting() {
 
@@ -44,8 +42,17 @@ fun Application.configurePostRouting() {
                     ?.map { PostItem::languages contains it }
                     ?.let ( filters::addAll )
 
+                // TODO: Error handling
+                val sortByFieldName = params["sortBy"].toString()
+                val sortByField = PostItem::class.memberProperties.first { prop -> prop.name == sortByFieldName }
+                val sort = when(params["sortDir"].toString()) {
+                    "asc" ->    ascending(sortByField)
+                    "desc" ->   descending(sortByField)
+                    else ->     ascending(sortByField)
+                }
+
                 val combinedFilter = and(filters) // One and() call combines all filters into a single bool query
-                call.respond(service.getPosts(combinedFilter))
+                call.respond(service.getPosts(combinedFilter, sort))
             }
 
             post {

--- a/api/src/main/kotlin/com/gmtkgamejam/plugins/PostRoutes.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/plugins/PostRoutes.kt
@@ -42,8 +42,9 @@ fun Application.configurePostRouting() {
                     ?.map { PostItem::languages contains it }
                     ?.let ( filters::addAll )
 
+                // Sorting
                 // TODO: Error handling
-                val sortByFieldName = params["sortBy"].toString()
+                val sortByFieldName = params["sortBy"] ?: "id"
                 val sortByField = PostItem::class.memberProperties.first { prop -> prop.name == sortByFieldName }
                 val sort = when(params["sortDir"].toString()) {
                     "asc" ->    ascending(sortByField)
@@ -51,8 +52,11 @@ fun Application.configurePostRouting() {
                     else ->     ascending(sortByField)
                 }
 
+                // Pagination
+                val page = params["page"]?.toInt() ?: 1
+
                 val combinedFilter = and(filters) // One and() call combines all filters into a single bool query
-                call.respond(service.getPosts(combinedFilter, sort))
+                call.respond(service.getPosts(combinedFilter, sort, page))
             }
 
             post {

--- a/api/src/main/kotlin/com/gmtkgamejam/services/PostService.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/services/PostService.kt
@@ -25,8 +25,8 @@ class PostService : KoinComponent {
         col.insertOne(postItem)
     }
 
-    fun getPosts(filter: Bson): List<PostItem> {
-        return col.find(filter).toList()
+    fun getPosts(filter: Bson, sort: Bson): List<PostItem> {
+        return col.find(filter).sort(sort).toList()
     }
 
     fun getPost(id: Long) : PostItem? {

--- a/api/src/main/kotlin/com/gmtkgamejam/services/PostService.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/services/PostService.kt
@@ -25,8 +25,10 @@ class PostService : KoinComponent {
         col.insertOne(postItem)
     }
 
-    fun getPosts(filter: Bson, sort: Bson): List<PostItem> {
-        return col.find(filter).sort(sort).toList()
+    fun getPosts(filter: Bson, sort: Bson, page: Int): List<PostItem> {
+        // TODO: Set to high value (config?) when running with more Posts in DB
+        val pageSize = 2
+        return col.find(filter).sort(sort).skip((page - 1) * pageSize).limit(pageSize).toList()
     }
 
     fun getPost(id: Long) : PostItem? {


### PR DESCRIPTION
Query string params changed:

`sortBy`: the field to sort by, any field on the PostItem member properties
`sortDir`: string of `asc` or `desc` 