### PR TITLE
Correctly add TTL to Auth collection and use Date format

### DIFF
--- a/api/src/main/kotlin/com/gmtkgamejam/models/AuthTokenSet.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/models/AuthTokenSet.kt
@@ -1,15 +1,17 @@
 package com.gmtkgamejam.models
 
+import java.util.*
+
 data class AuthTokenSet(
     val jwt: String,
     var accessToken: String,
     val tokenType: String,
-    var expiry: Long,
+    var expiry: Date,
     var refreshToken: String?,
 ) {
     fun refresh(refreshedTokenSet: DiscordRefreshTokenResponse) {
         this.accessToken = refreshedTokenSet.access_token
-        this.expiry = System.currentTimeMillis() + refreshedTokenSet.expires_in
+        this.expiry = Date(System.currentTimeMillis() + refreshedTokenSet.expires_in)
         this.refreshToken = refreshedTokenSet.refresh_token
     }
 }

--- a/api/src/main/kotlin/com/gmtkgamejam/plugins/Auth.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/plugins/Auth.kt
@@ -40,7 +40,7 @@ fun Application.configureAuthRouting() {
                     .sign(Algorithm.HMAC256(secret))
 
                 call.principal<OAuthAccessTokenResponse.OAuth2>()?.let {
-                    val tokenSet = AuthTokenSet(token, it.accessToken, it.tokenType, System.currentTimeMillis() + it.expiresIn, it.refreshToken)
+                    val tokenSet = AuthTokenSet(token, it.accessToken, it.tokenType, Date(System.currentTimeMillis() + it.expiresIn), it.refreshToken)
                     service.storeTokens(tokenSet)
 
                     val redirectTarget = environment.config.property("ui.host").getString()

--- a/api/src/main/kotlin/com/gmtkgamejam/plugins/Routing.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/plugins/Routing.kt
@@ -20,6 +20,7 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
+import java.util.*
 
 fun Application.configureRouting() {
 
@@ -57,7 +58,7 @@ fun Application.configureRouting() {
 
                     // If access token has expired, try a dirty inline refresh
                     var accessToken = tokenSet.accessToken
-                    val tokenHasExpired = tokenSet.expiry <= System.currentTimeMillis()
+                    val tokenHasExpired = tokenSet.expiry <= Date(System.currentTimeMillis())
                     if (tokenHasExpired) {
                         val refreshedTokenSet = client.post<DiscordRefreshTokenResponse>(refreshTokenEndpoint) {
                             body = FormDataContent(Parameters.build {

--- a/db/seed/Dockerfile
+++ b/db/seed/Dockerfile
@@ -1,7 +1,7 @@
 FROM mongo
 
-COPY data.json ./data.json
-CMD mongoimport --host db --port 27017 \
-    --db team-finder --collection posts \
-    --authenticationDatabase admin --username root --password example \
-    --drop --file /data.json --jsonArray
+COPY init-mongo.js data.json init.sh /
+
+RUN ["chmod", "+x", "/init.sh"]
+
+ENTRYPOINT ["/init.sh"]

--- a/db/seed/init-mongo.js
+++ b/db/seed/init-mongo.js
@@ -3,5 +3,9 @@
 db.auth("root", "example")
 db = db.getSiblingDB('team-finder')
 
+// Tear down existing auth collection context - sometimes we lose the index otherwise (for some reason)
+db.getCollection('auth').remove({})
+db.getCollection('auth').drop()
+
 // Create TTL for auth records
 db.getCollection('auth').createIndex( { "expiry": 1 }, { expireAfterSeconds: 10 } )

--- a/db/seed/init-mongo.js
+++ b/db/seed/init-mongo.js
@@ -1,0 +1,7 @@
+/** All interactive Mongo shell commands can be run from here - it's a lot easier in JS when you need loops etc */
+
+db.auth("root", "example")
+db = db.getSiblingDB('team-finder')
+
+// Create TTL for auth records
+db.getCollection('auth').createIndex( { "expiry": 1 }, { expireAfterSeconds: 10 } )

--- a/db/seed/init-mongo.js
+++ b/db/seed/init-mongo.js
@@ -8,4 +8,8 @@ db.getCollection('auth').remove({})
 db.getCollection('auth').drop()
 
 // Create TTL for auth records
-db.getCollection('auth').createIndex( { "expiry": 1 }, { expireAfterSeconds: 10 } )
+// The expiry field tracks the expiry of the accessToken, which is 10 minutes from issue;
+// We want to clear the record itself (including long-lived refreshToken) only when the token is no longer usable
+// Discord doesn't provide information on how long the refreshToken is valid for, but it's claimed up to 7 days
+// We use 1 day as a happy medium, as 24 hours since last activity seems like a reasonable amount of time to re-auth
+db.getCollection('auth').createIndex( { "expiry": 1 }, { expireAfterSeconds: 86400 } )

--- a/db/seed/init.sh
+++ b/db/seed/init.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+### Each top-level command should be triggered from here
+### This is because Docker only lets us do one CMD, but we want multiple commands to be able to reference 'db'
+
+# Import data.json to seed posts
+mongoimport --host db --port 27017 \
+  --db team-finder --collection posts \
+  --authenticationDatabase admin --username root --password example \
+  --drop --file /data.json --jsonArray
+
+# We run the init-mongo script against the 'admin' collection,
+# as that's where the user is defined/authenticated against
+mongo db:27017/admin /init-mongo.js


### PR DESCRIPTION
Clearing down the previous collection in `init-mongo.js` _seems_ to sort this problem out - one to keep an eye on.

> Draft WIP: the index seems to only work once. Not sure what's going on with that.

There's no clear answer for how long the `refresh_token` lives for (somewhere up to 7 days?), so I've gone for 24 hours semi-arbitrarily

> Also, we want the TTL to be the age of the `refresh_token`, not the `access_token`, as the `refresh_token` can regenerate the token set after original expiry.