### PR TITLE
Redirect to original UI page after login

### DIFF
--- a/ui/src/pages/AuthCallback/AuthCallback.tsx
+++ b/ui/src/pages/AuthCallback/AuthCallback.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { useAuthActions } from "../../utils/AuthContext";
+import { LOCAL_STORAGE_RETURN_AUTH_PATH_KEY } from "../../utils/login";
 
 export function AuthCallback(): React.ReactElement | null {
   const { setToken } = useAuthActions();
@@ -12,7 +13,8 @@ export function AuthCallback(): React.ReactElement | null {
   React.useEffect(() => {
     if (token) {
       setToken(token);
-      navigate("/");
+
+      navigate(localStorage.getItem(LOCAL_STORAGE_RETURN_AUTH_PATH_KEY) || "/");
     }
   }, [navigate, setToken, token]);
 

--- a/ui/src/utils/AuthContext.tsx
+++ b/ui/src/utils/AuthContext.tsx
@@ -2,8 +2,6 @@ import * as React from "react";
 import { useQueryClient } from "react-query";
 import { importMetaEnv } from "./importMeta";
 
-export const LOGIN_URL = `${importMetaEnv().VITE_API_URL}/login`;
-
 const LOCAL_STORAGE_KEY = "gmtkjam_auth";
 
 export interface AuthContextValue {

--- a/ui/src/utils/login.ts
+++ b/ui/src/utils/login.ts
@@ -1,0 +1,10 @@
+import {importMetaEnv} from "./importMeta";
+
+const LOGIN_URL = `${importMetaEnv().VITE_API_URL}/login`;
+
+export const LOCAL_STORAGE_RETURN_AUTH_PATH_KEY = "auth_redirect_path";
+
+export const login = () => {
+    localStorage.setItem(LOCAL_STORAGE_RETURN_AUTH_PATH_KEY, window.location.pathname);
+    window.location.href = LOGIN_URL;
+}

--- a/ui/src/utils/useEnsureLoggedIn.ts
+++ b/ui/src/utils/useEnsureLoggedIn.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useUserInfo } from "../queries/userInfo";
-import { LOGIN_URL, useAuth } from "./AuthContext";
+import { useAuth } from "./AuthContext";
+import { login } from "./login";
 
 /**
  * Note: While this does automatically redirect the user to the login page
@@ -14,7 +15,7 @@ export function useEnsureLoggedIn(): ReturnType<typeof useUserInfo> {
 
   React.useEffect(() => {
     if (!auth) {
-      window.location.href = LOGIN_URL;
+      login();
     }
   }, [auth]);
 


### PR DESCRIPTION
By refactoring the login logic into a single path, future login paths
should avoid losing the implicit dependency of login -> localStorage
path drop