### PR TITLE
Allow developers to easily set local log level

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -9,3 +9,4 @@ out/
 
 # Application
 logs/
+src/main/resources/logback-test.xml


### PR DESCRIPTION
A logback config file at this path will override `logback.xml`, so a developer can set their own logging config without risk of overriding common config