### PR TITLE
Standardise format of DB environment variables to match hosting needs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,14 +4,24 @@
 DISCORD_CLIENT_ID = CLIENT_ID
 DISCORD_CLIENT_SECRET = CLIENT_SECRET
 
-# Basic defaults for a MongoDB image
-# This will run a local database out of the box:
-DATABASE_USER = root
-DATABASE_PASSWORD = example
-DATABASE_HOST = db
-DATABASE_PORT = 27017
-DATABASE_PROTOCOL = mongodb
-DATABASE_CERT_PATH = unused-but-required
+### Database configuration ###
+# The format of a MongoDB URL is '$protocol://$user:$password@$host/$database'
+# (if using a non-standard DB port, use '$host:$port' instead of just '$host')
+
+# Connecting to local database from local
+#DATABASE_URL=mongodb://root:example@localhost/admin
+
+# Connecting to local database from Docker
+#DATABASE_URL=mongodb://root:example@db/admin
+
+# Connecting to remote DB from local
+#DATABASE_URL=mongodb+srv://team-finder-dev:$password@$host/team-finder?authSource=admin&replicaSet=db-mongodb-1&tls=true&tlsCAFile=$pathOnLocalMachine
+
+# Connecting to remote DB from Docker
+#DATABASE_URL=mongodb+srv://team-finder-dev:$password@$host/team-finder?authSource=admin&replicaSet=db-mongodb-1&tls=true&tlsCAFile=/opt/code/ca-certificate.crt
+
+# Connectiong to remote DB from remote API - here for reference only
+#DATABASE_URL = mongodb+srv://$user:$managedPassword@$host/admin?authSource=admin&tls=true
 
 # This configuration connections to the remote DB
 # Contact a project admin for credentials

--- a/api/src/main/kotlin/com/gmtkgamejam/koin/DatabaseModule.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/koin/DatabaseModule.kt
@@ -6,22 +6,7 @@ import org.litote.kmongo.KMongo
 
 val DatabaseModule = module(createdAtStart = true) {
     single {
-        val user = Config.getString("secrets.database.user")
-        val password = Config.getString("secrets.database.password")
-        val host = Config.getString("secrets.database.host")
-        val port = Config.getString("secrets.database.port")
-        val protocol = Config.getString("secrets.database.protocol")
-        val certPath = Config.getString("secrets.database.certPath")
-
-        if (protocol == "mongodb") {
-            // Create simple connection
-            KMongo.createClient("$protocol://$user:$password@$host:$port")
-        } else {
-            // FIXME: None of this should need breaking out into config values,
-            //        but 'team-finder' and the replicaSet can be changed externally
-            val settings = "team-finder?authSource=admin&replicaSet=db-mongodb-1&tls=true&tlsCAFile=$certPath"
-            KMongo.createClient("$protocol://$user:$password@$host/$settings")
-        }
-
+        val url = Config.getString("secrets.database.url")
+        KMongo.createClient(url)
     }
 }

--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -23,12 +23,7 @@ secrets {
     }
 
     database {
-        user = ${DATABASE_USER}
-        password = ${DATABASE_PASSWORD}
-        host = ${DATABASE_HOST}
-        port = ${DATABASE_PORT}
-        protocol = ${DATABASE_PROTOCOL}
-        certPath = ${DATABASE_CERT_PATH}
+        url = ${DATABASE_URL}
     }
 }
 


### PR DESCRIPTION
DigitalOcean passes in a managed DATABASE_URL string, with a frequently
changing password. While it's possible to use the individual fields directly
like we have been doing, the system doesn't encourage it.

Using a single environment variable should also make DB work easier for devs,
I hope!