### PR TITLE
Remove unneeded browser history state from back button

### DIFF
--- a/ui/src/pages/AuthCallback/AuthCallback.tsx
+++ b/ui/src/pages/AuthCallback/AuthCallback.tsx
@@ -14,7 +14,7 @@ export function AuthCallback(): React.ReactElement | null {
     if (token) {
       setToken(token);
 
-      navigate(localStorage.getItem(LOCAL_STORAGE_RETURN_AUTH_PATH_KEY) || "/");
+      navigate(localStorage.getItem(LOCAL_STORAGE_RETURN_AUTH_PATH_KEY) || "/", {replace: true});
     }
   }, [navigate, setToken, token]);
 


### PR DESCRIPTION
There's no way to remove the Discord stage from the back button, so pressing Back won't be a smooth experience, but it'll remove an ephemeral step from history 