### PR TITLE
Ensure last digits of ID don't get rounded to zeros

### DIFF
--- a/api/src/main/kotlin/com/gmtkgamejam/models/FavouritesDto.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/models/FavouritesDto.kt
@@ -9,5 +9,5 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class FavouritesDto (
-    var postId: Long,
+    var postId: String,
 )

--- a/api/src/main/kotlin/com/gmtkgamejam/models/FavouritesList.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/models/FavouritesList.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class FavouritesList(
     val discordId: String,
-    val postIds: MutableList<Long> = mutableListOf(),
+    val postIds: MutableList<String> = mutableListOf(),
 )

--- a/api/src/main/kotlin/com/gmtkgamejam/models/PostItem.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/models/PostItem.kt
@@ -4,10 +4,11 @@ import kotlinx.serialization.Serializable
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.ThreadLocalRandom
+import kotlin.math.abs
 
 @Serializable
 data class PostItem (
-    val id: Long,
+    val id: String,
 
     var author: String,
     var authorId: String,
@@ -37,7 +38,7 @@ data class PostItem (
             // TODO: Standardise datetime format
             val currentDatetime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
             return PostItem(
-                ThreadLocalRandom.current().nextLong(),
+                abs(ThreadLocalRandom.current().nextLong()).toString(), // We need to handle as string, otherwise we lose precision in JS
                 dto.author,
                 dto.authorId,
                 dto.title,

--- a/api/src/main/kotlin/com/gmtkgamejam/models/PostItemReportDto.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/models/PostItemReportDto.kt
@@ -7,5 +7,5 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class PostItemReportDto (
-    var id: Long,
+    var id: String,
 )

--- a/api/src/main/kotlin/com/gmtkgamejam/routing/AdminRoutes.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/routing/AdminRoutes.kt
@@ -35,7 +35,7 @@ fun Application.configureAdminRouting() {
                     }
                     post("/clear") {
                         val data = call.receive<ReportedUsersClearDto>()
-                        service.getPost(data.teamId.toLong())?.let {
+                        service.getPost(data.teamId)?.let {
                             it.reportCount = 0
                             service.updatePost(it)
                             return@post call.respond(it)
@@ -47,7 +47,7 @@ fun Application.configureAdminRouting() {
                 route("/post") {
                     delete {
                         val data = call.receive<DeletePostDto>()
-                        service.getPost(data.postId.toLong())?.let {
+                        service.getPost(data.postId)?.let {
                             service.deletePost(it)
                             return@delete call.respond(it)
                         }

--- a/api/src/main/kotlin/com/gmtkgamejam/routing/PostRoutes.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/routing/PostRoutes.kt
@@ -128,7 +128,7 @@ fun Application.configurePostRouting() {
             }
 
             get("{id}") {
-                val post: PostItem? = call.parameters["id"]?.toLong()?.let { service.getPost(it) }
+                val post: PostItem? = call.parameters["id"]?.let { service.getPost(it) }
                 post?.let { return@get call.respond(it) }
                 call.respondText("Post not found", status = HttpStatusCode.NotFound)
             }

--- a/api/src/main/kotlin/com/gmtkgamejam/services/PostService.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/services/PostService.kt
@@ -43,7 +43,7 @@ class PostService : KoinComponent {
         return col.find(filter).sort(sort).skip((page - 1) * pageSize).limit(pageSize).toList()
     }
 
-    fun getPost(id: Long) : PostItem? {
+    fun getPost(id: String) : PostItem? {
         return col.findOne(PostItem::id eq id)
     }
 

--- a/ui/src/model/post.ts
+++ b/ui/src/model/post.ts
@@ -5,7 +5,7 @@ import { Language } from "./language";
 import { TimezoneOffset } from "./timezone";
 
 export interface Post {
-  id: number;
+  id: string;
   title: string;
   author: string;
   authorId: string;

--- a/ui/src/queries/admin.ts
+++ b/ui/src/queries/admin.ts
@@ -37,7 +37,7 @@ export function useReportedPostsList(
 }
 
 interface DeletePostVariables {
-  postId: number;
+  postId: string;
 }
 export function useDeletePost(
   opts?: UseMutationOptions<void, Error, DeletePostVariables, unknown>

--- a/ui/src/queries/posts.ts
+++ b/ui/src/queries/posts.ts
@@ -90,7 +90,7 @@ export function usePostsList(
 const FAVOURITE_POST_QUERY_KEY = ["posts", "favourite"] as const;
 
 export interface FavouritePostMutationVariables {
-  postId: number;
+  postId: string;
   isFavourite?: boolean;
 }
 


### PR DESCRIPTION
Who'd have thought this bastard would reappear? Using `Long` data type for Post IDs leads to a loss of precision for larger values, and so the ID passed to the UI is incorrect (in testing, last three/four digits were `0000`).

This leads things like `isFavourite` logic to break, because random ID is being used for no reason.

Next time, we use UUIDs ISTG