### PR TITLE
Fix failed login behaviour caused by userinfo 404

### DIFF
--- a/ui/src/utils/apiRequest.ts
+++ b/ui/src/utils/apiRequest.ts
@@ -58,7 +58,7 @@ export async function apiRequest<T>(
     options["body"] = JSON.stringify(apiRequestOptions.body);
   }
 
-  const res = await fetch(`${importMetaEnv().VITE_API_URL}${path}/`, options);
+  const res = await fetch(`${importMetaEnv().VITE_API_URL}${path}`, options);
   if (!res.ok) {
     if (res.status === 401) {
       dependencies.logout();


### PR DESCRIPTION
This small change to the routing catches the API off-guard, and it doesn't know which route handler to send the request to