### PR TITLE
Reduce the super noisy MongoDB logging in prod

### DIFF
--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
             <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="trace">
+    <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>
     <logger name="org.eclipse.jetty" level="INFO"/>


### PR DESCRIPTION
This should be fine going forwards now we know the database is set up and behaving itself