### PR TITLE
Display full author name now that #1234 is no longer stored

### DIFF
--- a/ui/src/components/PostPreview/PostPreview.tsx
+++ b/ui/src/components/PostPreview/PostPreview.tsx
@@ -103,7 +103,7 @@ export const PreviewTitle: React.FC<{ post: Post }> = ({ post }) => {
       <img src={personIcon} className="inline-block" width={48} height={48} />
       <span className="inline-block grow">
         <h3 className="text-2xl">
-          {post.author.substring(0, post.author.length - 5)}
+          {post.author}
         </h3>
         <p>
           {post.size > 1


### PR DESCRIPTION
We used to store `Username#0000`, but this changed a while back