### PR TITLE
Display newline characters in post descriptions

### DIFF
--- a/ui/src/components/PostModal.tsx
+++ b/ui/src/components/PostModal.tsx
@@ -118,7 +118,10 @@ export const PostModal: React.FC<Props> = ({
           Timezones:{' '}
           {post.timezoneOffsets.map((t) => timezoneOffsetFromInt(t)).join(', ')}
         </p>
-        <p className="mb-16 mt-4 break-words" style={{wordBreak: "break-word"}}>{post.description}</p>
+
+        <div className="mb-16 mt-4 break-words" style={{wordBreak: "break-word"}}>
+          {post.description.split("\n").map(line => <p className="mb-1">{line}</p>)}
+        </div>
       </div>
 
       <MessageOnDiscordButton

--- a/ui/src/components/PostPreview/PostPreview.tsx
+++ b/ui/src/components/PostPreview/PostPreview.tsx
@@ -31,6 +31,8 @@ export const PostPreview: React.FC<Props> = ({
   const deletePostMutation = useDeletePost();
   const banUserMutation = useBanUser();
 
+  const description = post.description.length > 210 ? post.description.substring(0, 207) + "..." : post.description
+
   return (
     <article
       id={"post-" + post.id}
@@ -52,11 +54,9 @@ export const PostPreview: React.FC<Props> = ({
         className="[--skill-color:theme(colors.accent2)]"
         showText={showSkillText}
       />
-      <p className="break-words" style={{wordBreak: "break-word"}}>
-        {post.description.length <= 210
-          ? post.description
-          : post.description.substring(0, 210) + "..."}
-      </p>
+      <div className="break-words" style={{wordBreak: "break-word"}}>
+        {description.split("\n").map(line => <p className="mb-1">{line}</p>)}
+      </div>
 
       <PostModal
         post={post}


### PR DESCRIPTION
<img width="333" alt="image" src="https://user-images.githubusercontent.com/13312237/178800978-836c85f5-bc60-4192-912f-34ee1053e965.png">
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/13312237/178800991-75a8f352-8da4-410c-a29f-b7b7122fe14d.png">
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/13312237/178801029-8106b12e-8e3d-46a8-bf91-ea1d9a5de004.png">

The multiple line breaks get crushed down into one.

The `...` on the end of the modal is because the post is _just_ a smidge too long.