### PR TITLE
Bump Ktor version from 1.x to 2.0.3

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -5,12 +5,13 @@ val logback_version: String by project
 
 plugins {
     application
-    kotlin("jvm") version "1.5.30"
-    kotlin("plugin.serialization") version "1.5.21"
+    kotlin("jvm") version "1.7.10"
+    kotlin("plugin.serialization") version "1.7.10"
 }
 
 group = "com.gmtkgamejam"
-version = "0.0.1"
+version = "1.0.1"
+
 application {
     mainClass.set("com.gmtkgamejam.ApplicationKt")
 }
@@ -18,15 +19,8 @@ application {
 repositories {
     mavenCentral()
 }
+
 dependencies {
-    implementation("io.ktor:ktor-server-core:$ktor_version")
-    implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-auth:$ktor_version")
-    implementation("io.ktor:ktor-serialization:$ktor_version")
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-serialization:$ktor_version")
-    implementation("io.ktor:ktor-auth-jwt:$ktor_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
 
     // Logging support for Javacord
@@ -36,11 +30,31 @@ dependencies {
     implementation("io.insert-koin:koin-ktor:$koin_version")
 
     // DB
-    implementation("org.litote.kmongo:kmongo:4.2.8")
+    implementation("org.litote.kmongo:kmongo:4.6.1")
 
     // Discord bot
     implementation("org.javacord:javacord:3.4.0")
 
-    testImplementation("io.ktor:ktor-server-tests:$ktor_version")
+    // Ktor server core, auth, etc
+    implementation("io.ktor:ktor-server-core-jvm:$ktor_version")
+    implementation("io.ktor:ktor-server-netty-jvm:$ktor_version")
+    implementation("io.ktor:ktor-server-auth-jvm:$ktor_version")
+    implementation("io.ktor:ktor-server-auth-jwt-jvm:$ktor_version")
+    implementation("io.ktor:ktor-server-cors:$ktor_version")
+
+    // Ktor core for making web requests
+    implementation("io.ktor:ktor-client-core-jvm:$ktor_version")
+    implementation("io.ktor:ktor-client-cio-jvm:$ktor_version")
+
+    // Ktor serialisation
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+    // HTTP serialisation for HttpClient making external requests
+    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+    implementation("io.ktor:ktor-client-content-negotiation-jvm:$ktor_version")
+    // HTTP serialisation for receiving requests from the front end
+    implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
+    implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktor_version")
+
     testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlin_version")
+    testImplementation("io.ktor:ktor-server-tests-jvm:$ktor_version")
 }

--- a/api/gradle.properties
+++ b/api/gradle.properties
@@ -1,5 +1,12 @@
-ktor_version=1.6.1
-kotlin_version=1.5.30
-logback_version=1.2.3
+# Application language
+kotlin_version=1.7.10
 kotlin.code.style=official
-koin_version=3.1.2
+
+# Web framework
+ktor_version=2.0.3
+
+# DI framework for Ktor
+koin_version=3.2.0
+
+# Logging framework
+logback_version=1.2.11

--- a/api/src/main/kotlin/com/gmtkgamejam/Application.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/Application.kt
@@ -3,10 +3,11 @@ package com.gmtkgamejam
 import com.gmtkgamejam.koin.DatabaseModule
 import com.gmtkgamejam.koin.DiscordBotModule
 import com.gmtkgamejam.routing.*
-import io.ktor.application.*
-import io.ktor.features.*
 import io.ktor.http.*
-import io.ktor.serialization.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.application.*
+import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.plugins.cors.*
 import kotlinx.serialization.json.Json
 import org.koin.core.context.startKoin
 import org.koin.environmentProperties
@@ -15,39 +16,43 @@ fun main(args: Array<String>): Unit = io.ktor.server.netty.EngineMain.main(args)
 
 @Suppress("unused")
 fun Application.module() {
-    install(ContentNegotiation) {
-        json(Json {
-            prettyPrint = true
-            isLenient = true
-        })
-        install(CORS)
-        {
-            anyHost()
-
-            method(HttpMethod.Options)
-            method(HttpMethod.Head)
-            method(HttpMethod.Get)
-            method(HttpMethod.Post)
-            method(HttpMethod.Put)
-            method(HttpMethod.Patch)
-            method(HttpMethod.Delete)
-
-            header(HttpHeaders.XForwardedProto)
-            header(HttpHeaders.ContentType)
-            header(HttpHeaders.Authorization)
-            allowCredentials = true
-        }
-    }
-
     startKoin {
         environmentProperties()
         modules(DatabaseModule, DiscordBotModule)
     }
 
+    configureRequestHandling()
     configureUserInfoRouting()
     configureAuthRouting()
     configureAdminRouting()
     configurePostRouting()
     configureFavouritesRouting()
     configureDiscordBotRouting()
+}
+
+fun Application.configureRequestHandling() {
+    install(ContentNegotiation) {
+        json(Json {
+            prettyPrint = true
+            isLenient = true
+        })
+    }
+
+    install(CORS)
+    {
+        anyHost()
+
+        allowMethod(HttpMethod.Options)
+        allowMethod(HttpMethod.Head)
+        allowMethod(HttpMethod.Get)
+        allowMethod(HttpMethod.Post)
+        allowMethod(HttpMethod.Put)
+        allowMethod(HttpMethod.Patch)
+        allowMethod(HttpMethod.Delete)
+
+        allowHeader(HttpHeaders.XForwardedProto)
+        allowHeader(HttpHeaders.ContentType)
+        allowHeader(HttpHeaders.Authorization)
+        allowCredentials = true
+    }
 }

--- a/api/src/main/kotlin/com/gmtkgamejam/ApplicationResponseExtensions.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/ApplicationResponseExtensions.kt
@@ -1,9 +1,9 @@
 package com.gmtkgamejam
 
-import io.ktor.application.*
+import io.ktor.server.application.*
 import io.ktor.http.*
-import io.ktor.http.content.*
-import io.ktor.response.*
+import io.ktor.server.http.content.*
+import io.ktor.server.response.*
 
 suspend fun ApplicationCall.respondJSON(
     text: String,

--- a/api/src/main/kotlin/com/gmtkgamejam/AuthModule.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/AuthModule.kt
@@ -6,9 +6,9 @@ import com.auth0.jwt.algorithms.Algorithm
 import com.gmtkgamejam.Config
 import com.gmtkgamejam.discord.discordHttpClient
 import com.gmtkgamejam.services.AuthService
-import io.ktor.application.*
-import io.ktor.auth.*
-import io.ktor.auth.jwt.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.auth.jwt.*
 import io.ktor.http.*
 
 @Suppress("unused")

--- a/api/src/main/kotlin/com/gmtkgamejam/Config.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/Config.kt
@@ -1,6 +1,6 @@
 package com.gmtkgamejam
 
-import io.ktor.config.*
+import io.ktor.server.config.*
 
 // Use object to make Config a singleton reference
 // I truly hate that Ktor makes me do this

--- a/api/src/main/kotlin/com/gmtkgamejam/discord/GuildInfo.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/discord/GuildInfo.kt
@@ -2,6 +2,7 @@ package com.gmtkgamejam.discord
 
 import com.gmtkgamejam.Config
 import com.gmtkgamejam.models.JamGuildUserInfo
+import io.ktor.client.call.body
 import io.ktor.client.request.*
 import io.ktor.http.*
 
@@ -11,11 +12,13 @@ var guildInfo = "https://discordapp.com/api/users/@me/guilds/$guildId/member"
 
 suspend fun getGuildInfoAsync(accessToken: String): JamGuildUserInfo {
     return discordHttpClient().use { client ->
-        client.get(guildInfo) {
-            headers {
-                append(HttpHeaders.Accept, "application/json")
-                append(HttpHeaders.Authorization, "Bearer $accessToken")
+        client
+            .get(guildInfo) {
+                headers {
+                    append(HttpHeaders.Accept, "application/json")
+                    append(HttpHeaders.Authorization, "Bearer $accessToken")
+                }
             }
-        }
+            .body()
     }
 }

--- a/api/src/main/kotlin/com/gmtkgamejam/discord/HttpClient.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/discord/HttpClient.kt
@@ -2,15 +2,17 @@ package com.gmtkgamejam.discord
 
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
-import io.ktor.client.features.json.*
-import io.ktor.client.features.json.serializer.*
+import kotlinx.serialization.json.Json
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.*
 
 fun discordHttpClient(): HttpClient {
     return HttpClient(CIO) {
-        install(JsonFeature) {
-            serializer = KotlinxSerializer(kotlinx.serialization.json.Json {
-                isLenient = true
+        install(ContentNegotiation) {
+            json(Json {
                 ignoreUnknownKeys = true
+                isLenient = true
+                prettyPrint = true
             })
         }
     }

--- a/api/src/main/kotlin/com/gmtkgamejam/discord/RefreshToken.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/discord/RefreshToken.kt
@@ -1,21 +1,28 @@
 package com.gmtkgamejam.discord
 
 import com.gmtkgamejam.models.DiscordRefreshTokenResponse
+import io.ktor.client.call.body
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
 import io.ktor.http.*
 
 const val refreshTokenEndpoint = "https://discord.com/api/oauth2/token"
 
-suspend fun refreshTokenAsync(clientId: String, clientSecret: String, refreshToken: String): DiscordRefreshTokenResponse {
+suspend fun refreshTokenAsync(
+    clientId: String,
+    clientSecret: String,
+    refreshToken: String
+): DiscordRefreshTokenResponse {
     return discordHttpClient().use { client ->
-        client.post(refreshTokenEndpoint) {
-            body = FormDataContent(Parameters.build {
-                append("client_id", clientId)
-                append("client_secret", clientSecret)
-                append("grant_type", "refresh_token")
-                append("refresh_token", refreshToken)
-            })
-        }
+        client
+            .post(refreshTokenEndpoint) {
+                setBody(FormDataContent(Parameters.build {
+                    append("client_id", clientId)
+                    append("client_secret", clientSecret)
+                    append("grant_type", "refresh_token")
+                    append("refresh_token", refreshToken)
+                }))
+            }
+            .body()
     }
 }

--- a/api/src/main/kotlin/com/gmtkgamejam/discord/UserInfo.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/discord/UserInfo.kt
@@ -1,6 +1,7 @@
 package com.gmtkgamejam.discord
 
 import com.gmtkgamejam.models.DiscordUserInfo
+import io.ktor.client.call.body
 import io.ktor.client.request.*
 import io.ktor.http.*
 
@@ -8,11 +9,13 @@ const val userInfo = "https://discordapp.com/api/users/@me"
 
 suspend fun getUserInfoAsync(accessToken: String): DiscordUserInfo {
     return discordHttpClient().use { client ->
-        client.get(userInfo) {
-            headers {
-                append(HttpHeaders.Accept, "application/json")
-                append(HttpHeaders.Authorization, "Bearer $accessToken")
+        client
+            .get(userInfo) {
+                headers {
+                    append(HttpHeaders.Accept, "application/json")
+                    append(HttpHeaders.Authorization, "Bearer $accessToken")
+                }
             }
-        }
+            .body()
     }
 }

--- a/api/src/main/kotlin/com/gmtkgamejam/routing/AdminRoutes.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/routing/AdminRoutes.kt
@@ -8,12 +8,12 @@ import com.gmtkgamejam.models.admin.ReportedUsersClearDto
 import com.gmtkgamejam.respondJSON
 import com.gmtkgamejam.services.AdminService
 import com.gmtkgamejam.services.PostService
-import io.ktor.application.*
-import io.ktor.auth.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
 import io.ktor.http.*
-import io.ktor.request.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import org.litote.kmongo.and
 import org.litote.kmongo.descending
 import org.litote.kmongo.eq

--- a/api/src/main/kotlin/com/gmtkgamejam/routing/AuthRoutes.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/routing/AuthRoutes.kt
@@ -6,10 +6,10 @@ import com.gmtkgamejam.Config
 import com.gmtkgamejam.discord.getUserInfoAsync
 import com.gmtkgamejam.models.AuthTokenSet
 import com.gmtkgamejam.services.AuthService
-import io.ktor.application.*
-import io.ktor.auth.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import java.security.SecureRandom
 import java.util.*
 
@@ -41,7 +41,14 @@ fun Application.configureAuthRouting() {
 
                 call.principal<OAuthAccessTokenResponse.OAuth2>()?.let {
                     val user = getUserInfoAsync(it.accessToken)
-                    val tokenSet = AuthTokenSet(randomId, user.id, it.accessToken, it.tokenType, Date(System.currentTimeMillis() + it.expiresIn), it.refreshToken)
+                    val tokenSet = AuthTokenSet(
+                        randomId,
+                        user.id,
+                        it.accessToken,
+                        it.tokenType,
+                        Date(System.currentTimeMillis() + it.expiresIn),
+                        it.refreshToken
+                    )
                     service.storeTokenSet(tokenSet)
 
                     val redirectTarget = Config.getString("ui.host")
@@ -52,7 +59,7 @@ fun Application.configureAuthRouting() {
     }
 }
 
-fun getSecureId() : String {
+fun getSecureId(): String {
     // Arbitrary array size, but inflated to give overflow in case byte->string encoding drops any characters
     val bytes = ByteArray(64)
     SecureRandom().nextBytes(bytes)

--- a/api/src/main/kotlin/com/gmtkgamejam/routing/FavouritesRoutes.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/routing/FavouritesRoutes.kt
@@ -4,13 +4,13 @@ import com.gmtkgamejam.models.FavouritesDto
 import com.gmtkgamejam.respondJSON
 import com.gmtkgamejam.services.AuthService
 import com.gmtkgamejam.services.FavouritesService
-import io.ktor.application.*
-import io.ktor.auth.*
-import io.ktor.auth.jwt.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.auth.jwt.*
 import io.ktor.http.*
-import io.ktor.request.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 
 fun Application.configureFavouritesRouting() {
 

--- a/api/src/main/kotlin/com/gmtkgamejam/routing/UserInfoRoutes.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/routing/UserInfoRoutes.kt
@@ -8,12 +8,12 @@ import com.gmtkgamejam.discord.refreshTokenAsync
 import com.gmtkgamejam.models.UserInfo
 import com.gmtkgamejam.respondJSON
 import com.gmtkgamejam.services.AuthService
-import io.ktor.application.*
-import io.ktor.auth.*
-import io.ktor.auth.jwt.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.auth.jwt.*
 import io.ktor.http.*
-import io.ktor.response.*
-import io.ktor.routing.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import org.koin.ktor.ext.inject
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory


### PR DESCRIPTION
Bit of a monster, sorry! A few of our dependencies had vulnerabilities (see picture) that required bumping. 

Given that Ktor v2 is out (and the latest version of Ktor v1 is `1.6.8` but isn't clearly marked as LTS), I thought it'd be prudent to make the jump to Ktor v2 and bring all our deps up to latest. The Ktor docs always land on the latest version (e.g. from a google search), so this'll hopefully make life a bit easier for the API devs going forwards.

Also the testing libraries are a bit different between the two, and I _really_ didn't want to test > upgrade > rewrite tests 😅 

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/13312237/181750263-68bfaecd-25a5-429a-a950-365f6410d5dd.png">
