### PR TITLE
Install devDependencies in Dockerfile.dev of the ui project after volume mount has happened

### DIFF
--- a/ui/Dockerfile.dev
+++ b/ui/Dockerfile.dev
@@ -8,7 +8,8 @@ ENV NODE_ENV production
 
 # Thin-install app dependencies
 COPY package.json package-lock.json ./
-RUN npm install --silent
+# Dependencies will be installed in docker-entrypoint.sh, so after the volume mount
+# RUN npm install --silent
 
 # Add app; non-prod files still useful for local dev
 COPY . ./

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+npm install --production=false --silent
 npm rebuild esbuild
 
 exec "$@"


### PR DESCRIPTION
With this PR the following things will happen:
- Project packages will be installed after the volume mount has happened (installation at docker entrypoint).
- devDependencies will be installed as well with `npm install --production=false --silent` even though `NODE_ENV` is set to production.

Fixes #261.