### PR TITLE
Fix incorrect nextYear in AfterJam

### DIFF
--- a/ui/src/pages/AfterJam/AfterJam.tsx
+++ b/ui/src/pages/AfterJam/AfterJam.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { importMetaEnv } from "../../utils/importMeta";
 
 const jamName = importMetaEnv().VITE_JAM_NAME;
-const nextYear = new Date().getFullYear() + 1
+const nextYear = new Date(importMetaEnv().VITE_JAM_END).getFullYear() + 1;
 
 export const AfterJam: React.FC = () => {
   return (

--- a/ui/src/utils/jamState.ts
+++ b/ui/src/utils/jamState.ts
@@ -14,7 +14,7 @@ export const getJamState = () => {
 
   const currentDate = new Date();
 
-  // If an end date hasn't been given, never show the BeforeJam view
+  // If a start date hasn't been given, never show the BeforeJam view
   const jamStartDate = new Date(importMetaEnv().VITE_JAM_START || "1999-01-01");
   if (currentDate <= jamStartDate) {
     return JamState.Before;


### PR DESCRIPTION
The next jam's year was calculated from the current date, which only makes sense in the year when the jam ends. I changed it to be calculated based on the jam's end date instead.