### PR TITLE
Notify users of fallback contact via DM instead of channel ping

### DIFF
--- a/api/src/main/kotlin/com/gmtkgamejam/bot/BotMessageBuilder.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/bot/BotMessageBuilder.kt
@@ -1,0 +1,52 @@
+package com.gmtkgamejam.bot
+
+import com.gmtkgamejam.services.PostService
+import org.javacord.api.entity.message.embed.EmbedBuilder
+import org.javacord.api.entity.user.User
+
+class BotMessageBuilder {
+
+    private val postService = PostService()
+
+    fun canBuildEmbedFromUser(sender: User): Boolean = postService.getPostByAuthorId(sender.id.toString()) != null
+
+    fun embedMessage(recipient: User, sender: User): EmbedBuilder {
+        val post = postService.getPostByAuthorId(sender.id.toString())!!
+
+        val shortDescription = if (post.description.length > 240) post.description.take(237) + "..." else post.description
+
+        val embed = EmbedBuilder()
+            .setTitle("${sender.name} wants to get in contact!")
+            .setDescription("Hey there ${recipient.name}! ${sender.name} wants to get in touch - this is a summary of their current post on the Team Finder!")
+            .setAuthor("GMTK Team Finder", "https://findyourjam.team/", "https://findyourjam.team/logos/jam-logo-stacked.webp")
+            .addField("Description", shortDescription)
+
+        // Add optional fields - turns out this includes timezones
+        if (post.skillsSought?.isNotEmpty() == true) {
+            embed.addField("${sender.name} is looking for:", post.skillsSought.toString())
+        }
+        if (post.skillsPossessed?.isNotEmpty() == true) {
+            embed.addField("${sender.name} can bring:", post.skillsPossessed.toString())
+        }
+        if (post.preferredTools?.isNotEmpty() == true) {
+            embed.addField("Engine(s)", post.preferredTools.toString())
+        }
+        if (post.timezoneOffsets.isNotEmpty()) {
+            embed.addField("Timezone(s)", post.timezoneOffsets.map { if (it < 0) "UTC-$it" else "UTC+$it" }.toString())
+        }
+
+        embed
+            .addField("Like what you see?", "Check out their full post here to see more! https://findyourjam.team/gmtk/${post.id}/")
+            .setFooter("Feedback? DM @dotwo in the #developing-gtmk-team-finder-app channel")
+
+        return embed
+    }
+
+    // TODO: Add a variety of messages to mix things up a bit?
+    fun basicMessage(recipient: User, sender: User): String {
+        return """
+            Hey ${recipient.mentionTag}, ${sender.mentionTag} wants to get in contact about your Team Finder post!
+            They don't have a post on the Team Finder yet, so why not drop them a message and find out more?
+        """.trimIndent()
+    }
+}

--- a/api/src/main/kotlin/com/gmtkgamejam/models/posts/Skills.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/models/posts/Skills.kt
@@ -1,13 +1,17 @@
 package com.gmtkgamejam.models.posts
 
-enum class Skills {
-    ART_2D,
-    ART_3D,
-    CODE,
-    DESIGN_PRODUCTION,
-    SFX,
-    MUSIC,
-    TESTING_SUPPORT,
-    TEAM_LEAD,
-    OTHER;
+enum class Skills(private var readableName: String) {
+    ART_2D("2D Art"),
+    ART_3D("3D Art"),
+    CODE("Code"),
+    DESIGN_PRODUCTION("Design/Production"),
+    SFX("SFX"),
+    MUSIC("Music"),
+    TESTING_SUPPORT("Testing/Support"),
+    TEAM_LEAD("Team lead"),
+    OTHER("Other");
+
+    override fun toString(): String {
+        return readableName;
+    }
 }

--- a/api/src/main/kotlin/com/gmtkgamejam/models/posts/Tools.kt
+++ b/api/src/main/kotlin/com/gmtkgamejam/models/posts/Tools.kt
@@ -1,15 +1,19 @@
 package com.gmtkgamejam.models.posts
 
 // For the time being, Tool == Engine
-enum class Tools {
-    UNITY,
-    CONSTRUCT,
-    GAME_MAKER_STUDIO,
-    GODOT,
-    TWINE,
-    BITSY,
-    UNREAL,
-    RPG_MAKER,
-    PICO_8,
-    OTHER,
+enum class Tools(private var readableName: String) {
+    UNITY("Unity"),
+    CONSTRUCT("Construct"),
+    GAME_MAKER_STUDIO("Game Maker Studio"),
+    GODOT("Godot"),
+    TWINE("Twine"),
+    BITSY("Bitsy"),
+    UNREAL("Unreal"),
+    RPG_MAKER("RPG Maker"),
+    PICO_8("PICO 8"),
+    OTHER("Other");
+
+    override fun toString(): String {
+        return readableName;
+    }
 }

--- a/ui/src/pages/post/Post.tsx
+++ b/ui/src/pages/post/Post.tsx
@@ -154,7 +154,7 @@ const MessageOnDiscordButton: React.FC<{
             {canPostAuthorBeDMd && <DiscordMessageButton authorId={authorId} author={author} isLoggedIn={isLoggedIn} />}
 
             {inDiscordServer
-                ? <DiscordPingButton authorId={authorId} createBotDmMutation={createBotDmMutation} message={fallbackPingMessage} />
+                ? <DiscordPingButton authorId={authorId} authorName={author} createBotDmMutation={createBotDmMutation} message={fallbackPingMessage} />
                 : <>
                     <p>Sorry, you can&apos;t contact this user right now.</p>
                     <p>

--- a/ui/src/pages/post/components/DiscordPingButton.tsx
+++ b/ui/src/pages/post/components/DiscordPingButton.tsx
@@ -1,14 +1,29 @@
 import React from "react";
+import {toast} from "react-hot-toast";
 
 export const DiscordPingButton: React.FC<{
     authorId: string,
+    authorName: string,
     createBotDmMutation: any,
     message: string
 }> = ({
     authorId,
+    authorName,
     createBotDmMutation,
     message,
 }) => {
+
+    const onClick = () => {
+        createBotDmMutation.mutate({
+            recipientId: authorId,
+        }, {
+            onSuccess: () => {
+                toast(`${authorName} has just been notified that you want to get in touch!`);
+            },
+
+        });
+    };
+
     return (
         <>
             <p className="mb-2">{message}</p>
@@ -16,7 +31,7 @@ export const DiscordPingButton: React.FC<{
                 <a
                     target="_blank"
                     rel="noreferrer"
-                    onClick={() => createBotDmMutation.mutate({ recipientId: authorId })}
+                    onClick={onClick}
                     className="text-sm"
                 >
                     Ping them on Discord


### PR DESCRIPTION
Now when clicking the "Ping them on discord" button on the UI (ideally to be used when a user doesn't have the correct permissions to receive DMs from users), the user will be send a message from the server bot.

If a user has locked down their permissions such that they can't receive a DM from the bot, then they'll currently be stuck as uncontactable. However, given that the bot is currently also running the user permissions check on login, we shouldn't be able to get to this position for the majority of users who create a post under normal conditions.

I'd prefer to remove the ping channel entirely and rely on our onboarding process to catch users who can't receive messages, now that we have the ability to report posts as uncontactable. However, while we have the ping channel we might want to keep it as the ultimate fallback in case of exception user behaviour.

## Screenshots
**Normal; sender has a post on the site, all fields**
<img width="419" alt="image" src="https://github.com/GameMakersToolkit/team-finder/assets/13312237/658f8774-6483-48c9-95f5-727c627aac87">

**Normal; sender has a post on the site, but not all fields**
<img width="477" alt="image" src="https://github.com/GameMakersToolkit/team-finder/assets/13312237/d06c3e9b-5983-418d-90c2-2e903d7c1b2a">

**Normal; send doesn't have a post on the site**
![image](https://github.com/GameMakersToolkit/team-finder/assets/13312237/ab8dc0dd-a270-4187-9978-91d34dc47d43)
(The typo'd `"` has been fixed)

**When a user has blocked all contact**
<img width="540" alt="image" src="https://github.com/GameMakersToolkit/team-finder/assets/13312237/6cf61f9e-f088-47ac-a83b-32fa38b20043">
<img width="1336" alt="image" src="https://github.com/GameMakersToolkit/team-finder/assets/13312237/8bf2fccb-7209-4194-bb79-a8835ef49ede">
